### PR TITLE
Add optional server shutdown delay + announcement

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func main() {
 
 		case exitCode := <-cmdExitChan:
 			logger.Info("Done")
+			defer logger.Sync()
 			os.Exit(exitCode)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	}
 	defer logger.Sync()
 	logger = logger.Named("mc-server-runner")
+	logger.Info("startup")
 
 	var cmd *exec.Cmd
 
@@ -146,6 +147,7 @@ func main() {
 		case <-signalChan:
 			if args.StopServerAnnounceDelay >= 0 {
 				announceStopViaConsole(logger, stdin, args.StopServerAnnounceDelay)
+				logger.Info("Sleeping before server stop", zap.Duration("sleepTime", args.StopServerAnnounceDelay))
 				time.Sleep(args.StopServerAnnounceDelay)
 			}
 
@@ -208,7 +210,7 @@ func stopWithRconCli() error {
 }
 
 func announceStopViaConsole(logger *zap.Logger, stdin io.Writer, shutdownDelay time.Duration) {
-	logger.Info("Sending shutdown announce 'say' to Minecraft server...")
+	logger.Info("Sending shutdown announce 'say' to Minecraft server")
 	_, err := stdin.Write([]byte(fmt.Sprintf("say Server shutting down in %0.f seconds\n", shutdownDelay.Seconds())))
 	if err != nil {
 		logger.Error("ERROR failed to write say command to server console", zap.Error(err))

--- a/main.go
+++ b/main.go
@@ -3,10 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/itzg/go-flagsfiller"
-	"github.com/itzg/mc-server-runner/cfsync"
-	"github.com/itzg/zapconfigs"
-	"go.uber.org/zap"
 	"io"
 	"io/ioutil"
 	"log"
@@ -16,6 +12,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/itzg/go-flagsfiller"
+	"github.com/itzg/mc-server-runner/cfsync"
+	"github.com/itzg/zapconfigs"
+	"go.uber.org/zap"
 )
 
 type Args struct {

--- a/main.go
+++ b/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Args struct {
-	Debug        bool          `usage:"Enable debug logging"`
-	Bootstrap    string        `usage:"Specifies a file with commands to initially send to the server"`
-	StopDuration time.Duration `usage:"Amount of time in Golang duration to wait after sending the 'stop' command."`
-	DetachStdin  bool          `usage:"Don't forward stdin and allow process to be put in background"`
-	Shell        string        `usage:"When set, pass the arguments to this shell"`
-	Cf           struct {
+	Debug                   bool          `usage:"Enable debug logging"`
+	Bootstrap               string        `usage:"Specifies a file with commands to initially send to the server"`
+	StopDuration            time.Duration `usage:"Amount of time in Golang duration to wait after sending the 'stop' command."`
+	StopServerAnnounceDelay time.Duration `default:"0s" usage:"Amount of time in Golang duration to wait after announcing server shutdown"`
+	DetachStdin             bool          `usage:"Don't forward stdin and allow process to be put in background"`
+	Shell                   string        `usage:"When set, pass the arguments to this shell"`
+	Cf                      struct {
 		InstanceFile string `usage:"Path to a Twitch/Curse minecraftinstance.json file for server setup"`
 	}
 }

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 	for {
 		select {
 		case <-signalChan:
-			if args.StopServerAnnounceDelay >= 0 {
+			if args.StopServerAnnounceDelay > 0 {
 				announceStopViaConsole(logger, stdin, args.StopServerAnnounceDelay)
 				logger.Info("Sleeping before server stop", zap.Duration("sleepTime", args.StopServerAnnounceDelay))
 				time.Sleep(args.StopServerAnnounceDelay)

--- a/main.go
+++ b/main.go
@@ -201,6 +201,14 @@ func stopWithRconCli() error {
 	return rconCliCmd.Run()
 }
 
+func announceStopViaConsole(logger *zap.Logger, stdin io.Writer, shutdownDelay time.Duration) {
+	logger.Info("Sending shutdown announce 'say' to Minecraft server...")
+	_, err := stdin.Write([]byte(fmt.Sprintf("say Server shutting down in %0.f seconds\n", shutdownDelay.Seconds())))
+	if err != nil {
+		logger.Error("ERROR failed to write say command to server console", zap.Error(err))
+	}
+}
+
 func stopViaConsole(logger *zap.Logger, stdin io.Writer) {
 	logger.Info("Sending 'stop' to Minecraft server...")
 	_, err := stdin.Write([]byte("stop\n"))

--- a/main.go
+++ b/main.go
@@ -143,6 +143,11 @@ func main() {
 	for {
 		select {
 		case <-signalChan:
+			if args.StopServerAnnounceDelay >= 0 {
+				announceStopViaConsole(logger, stdin, args.StopServerAnnounceDelay)
+				time.Sleep(args.StopServerAnnounceDelay)
+			}
+
 			if hasRconCli() {
 				err := stopWithRconCli()
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -50,7 +50,6 @@ func main() {
 	}
 	defer logger.Sync()
 	logger = logger.Named("mc-server-runner")
-	logger.Info("startup")
 
 	var cmd *exec.Cmd
 
@@ -133,7 +132,7 @@ func main() {
 					zap.Int("exitCode", exitCode))
 				cmdExitChan <- exitCode
 			} else {
-				logger.Error("command failed abnormally", zap.Error(waitErr))
+				logger.Error("Command failed abnormally", zap.Error(waitErr))
 				cmdExitChan <- 1
 			}
 			return
@@ -154,7 +153,7 @@ func main() {
 			if hasRconCli() {
 				err := stopWithRconCli()
 				if err != nil {
-					logger.Error("ERROR Failed to stop using rcon-cli", zap.Error(err))
+					logger.Error("Failed to stop using rcon-cli", zap.Error(err))
 					stopViaConsole(logger, stdin)
 				}
 			} else {
@@ -164,10 +163,10 @@ func main() {
 			logger.Info("Waiting for completion...")
 			if args.StopDuration != 0 {
 				time.AfterFunc(args.StopDuration, func() {
-					logger.Error("ERROR Took too long, so killing server process")
+					logger.Error("Took too long, so killing server process")
 					err := cmd.Process.Kill()
 					if err != nil {
-						logger.Error("ERROR failed to forcefully kill process")
+						logger.Error("Failed to forcefully kill process")
 					}
 				})
 			}
@@ -214,7 +213,7 @@ func announceStopViaConsole(logger *zap.Logger, stdin io.Writer, shutdownDelay t
 	logger.Info("Sending shutdown announce 'say' to Minecraft server")
 	_, err := stdin.Write([]byte(fmt.Sprintf("say Server shutting down in %0.f seconds\n", shutdownDelay.Seconds())))
 	if err != nil {
-		logger.Error("ERROR failed to write say command to server console", zap.Error(err))
+		logger.Error("Failed to write say command to server console", zap.Error(err))
 	}
 }
 
@@ -222,7 +221,7 @@ func stopViaConsole(logger *zap.Logger, stdin io.Writer) {
 	logger.Info("Sending 'stop' to Minecraft server...")
 	_, err := stdin.Write([]byte("stop\n"))
 	if err != nil {
-		logger.Error("ERROR failed to write stop command to server console", zap.Error(err))
+		logger.Error("Failed to write stop command to server console", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
My first Go! 😅

* adds: new argument `StopServerAnnounceDelay` of type time.Duration - defaults to `0s`
* adds: new helper method `announceStopViaConsole()` - my attempt at string formatting 👍 
* adds: logic to announce server shutdown if argument `StopServerAnnounceDelay` > 0, then `time.Sleep(StopServerAnnounceDelay)` 
* adds: few more log statements

Please tweak as you see fit, or let me know what you'd like to see changed to better reflect whatever vision you already had for this capability. Thanks for such a great project!

Refs https://github.com/itzg/mc-server-runner/issues/10