### PR TITLE
Add environment variable to pass a config yaml file to rcon-cli on stop

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,23 +172,33 @@ func hasRconCli() bool {
 }
 
 func stopWithRconCli() error {
-	port := os.Getenv("RCON_PORT")
-	if port == "" {
-		port = "25575"
-	}
-
-	password := os.Getenv("RCON_PASSWORD")
-	if password == "" {
-		password = "minecraft"
-	}
-
 	log.Println("Stopping with rcon-cli")
-	rconCliCmd := exec.Command("rcon-cli",
-		"--port", port,
-		"--password", password,
-		"stop")
 
-	return rconCliCmd.Run()
+	rconConfigFile := os.Getenv("RCON_CONFIG_FILE")
+	if rconConfigFile == "" {
+		port := os.Getenv("RCON_PORT")
+		if port == "" {
+			port = "25575"
+		}
+
+		password := os.Getenv("RCON_PASSWORD")
+		if password == "" {
+			password = "minecraft"
+		}
+
+		rconCliCmd := exec.Command("rcon-cli",
+			"--port", port,
+			"--password", password,
+			"stop")
+
+		return rconCliCmd.Run()
+	} else {
+		rconCliCmd := exec.Command("rcon-cli",
+			"--config", rconConfigFile,
+			"stop")
+
+		return rconCliCmd.Run()
+	}
 }
 
 func announceStopViaConsole(logger *zap.Logger, stdin io.Writer, shutdownDelay time.Duration) {


### PR DESCRIPTION
This runner has been useful to me when setting up a server that is controlled using an init system outside of a container context to ensure a graceful shutdown when the init service stops the Minecraft server. When running through an init system, it is often convenient to access the server via a local-only rcon port. Since I like to avoid duplication of configs, I wanted to have this script accept a config yaml file to pass to rcon-cli so that I don't have to maintain the config in the runner's environment as well, so I added the RCON_CONFIG_FILE environment variable to support this scenario.

It's a very simple addition that passes rcon settings via the yaml file if it is specified, but then defaults to reading from the existing environment variables that were already implemented.

I figured I might as well contribute this change back upstream in case others find this tool useful in a similar scenario as myself.