### PR TITLE
Directly attach stdin/out/err by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.20.10"
+      go-version: "1.21.6"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,13 +10,12 @@ builds:
 - goos:
   - linux
   goarch:
-  - 386
   - amd64
   - arm
   - arm64
   goarm:
-  - 6
-  - 7
+  - "6"
+  - "7"
   main: .
   env:
     - CGO_ENABLED=0
@@ -25,8 +24,6 @@ archives:
   - format_overrides:
       - goos: windows
         format: zip
-snapshot:
-  name_template: SNAPSHOT-{{ .Commit }}
 changelog:
   filters:
     exclude:

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -67,14 +68,43 @@ func main() {
 		logger.Error("Unable to get stdin", zap.Error(err))
 	}
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		logger.Error("Unable to get stdout", zap.Error(err))
-	}
+	if args.RemoteConsole {
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			logger.Error("Unable to get stdout", zap.Error(err))
+		}
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		logger.Error("Unable to get stderr", zap.Error(err))
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			logger.Error("Unable to get stderr", zap.Error(err))
+		}
+
+		console := makeConsole(stdin, stdout, stderr)
+
+		// Relay stdin between outside and server
+		if !args.DetachStdin {
+			go consoleInRoutine(os.Stdin, console, logger)
+		}
+
+		go consoleOutRoutine(os.Stdout, console, stdOutTarget, logger)
+		go consoleOutRoutine(os.Stderr, console, stdErrTarget, logger)
+
+		go runRemoteShellServer(console, logger)
+
+		logger.Info("Running with remote console support")
+	} else {
+		logger.Debug("Directly assigning stdout/stderr")
+		// directly assign stdout/err to pass through terminal, if applicable
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if hasRconCli() {
+			logger.Debug("Directly assigning stdin")
+			cmd.Stdin = os.Stdin
+			stdin = os.Stdin
+		} else {
+			go relayStdin(logger, stdin)
+		}
 	}
 
 	err = cmd.Start()
@@ -93,26 +123,11 @@ func main() {
 		}
 	}
 
-	console := makeConsole(stdin, stdout, stderr)
-
-	// Relay stdin between outside and server
-	if !args.DetachStdin {
-		go consoleInRoutine(os.Stdin, console, logger)
-	}
-
-	go consoleOutRoutine(os.Stdout, console, stdOutTarget, logger)
-	go consoleOutRoutine(os.Stderr, console, stdErrTarget, logger)
-
-	// Start the remote server if intended
-	if args.RemoteConsole {
-		go startRemoteShellServer(console, logger)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	errors := make(chan error, 1)
+	errorChan := make(chan error, 1)
 
 	if args.NamedPipe != "" {
-		err2 := handleNamedPipe(ctx, args.NamedPipe, stdin, errors)
+		err2 := handleNamedPipe(ctx, args.NamedPipe, stdin, errorChan)
 		if err2 != nil {
 			logger.Fatal("Failed to setup named pipe", zap.Error(err2))
 		}
@@ -123,14 +138,12 @@ func main() {
 	go func() {
 		waitErr := cmd.Wait()
 		if waitErr != nil {
-			if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			var exitErr *exec.ExitError
+			if errors.As(waitErr, &exitErr) {
 				exitCode := exitErr.ExitCode()
 				logger.Warn("Minecraft server failed. Inspect logs above for errors that indicate cause. DO NOT report this line as an error.",
 					zap.Int("exitCode", exitCode))
 				cmdExitChan <- exitCode
-			} else {
-				logger.Error("Command failed abnormally", zap.Error(waitErr))
-				cmdExitChan <- 1
 			}
 			return
 		} else {
@@ -168,7 +181,7 @@ func main() {
 				})
 			}
 
-		case namedPipeErr := <-errors:
+		case namedPipeErr := <-errorChan:
 			logger.Error("Error during named pipe handling", zap.Error(namedPipeErr))
 
 		case exitCode := <-cmdExitChan:
@@ -178,6 +191,13 @@ func main() {
 		}
 	}
 
+}
+
+func relayStdin(logger *zap.Logger, stdin io.WriteCloser) {
+	_, err := io.Copy(stdin, os.Stdin)
+	if err != nil {
+		logger.Error("Failed to relay standard input", zap.Error(err))
+	}
 }
 
 func hasRconCli() bool {

--- a/remote_shell_service.go
+++ b/remote_shell_service.go
@@ -183,7 +183,7 @@ func consoleOutRoutine(output io.Writer, console *Console, target ConsoleTarget,
 
 // Use os.Stdin for console.
 func consoleInRoutine(stdIn io.Reader, console *Console, logger *zap.Logger) {
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(stdIn)
 	for scanner.Scan() {
 		text := scanner.Text()
 		outBytes := []byte(fmt.Sprintf("%s\n", text))
@@ -229,7 +229,7 @@ func ensureHostKey(logger *zap.Logger) (string, error) {
 	return keyfilePath, err
 }
 
-func startRemoteShellServer(console *Console, logger *zap.Logger) {
+func runRemoteShellServer(console *Console, logger *zap.Logger) {
 	logger.Info("Starting remote shell server on 2222...")
 	ssh.Handle(func(s ssh.Session) { handleSession(s, console, logger) })
 


### PR DESCRIPTION
Discussed [in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1198277528637423626)

Restores default behavior that was altered by https://github.com/itzg/mc-server-runner/pull/56

Enhances #12  by announcing via rcon when enabled

Upgrade Go to 1.21.6