### PR TITLE
Support both ECDSA + RSA for SSH Server

### DIFF
--- a/remote_shell_service.go
+++ b/remote_shell_service.go
@@ -363,13 +363,14 @@ func ensureHostKeys(logger *zap.Logger) (*hostKeys, error) {
 
 	keyfilePath := pickHostKeyPath(homeDir)
 	defaultKeyfilePath := filepath.Join(homeDir, HostKeyFilename)
+	fileChanged := keyfilePath != defaultKeyfilePath
 	_, err = os.Stat(keyfilePath)
 	if os.IsNotExist(err) {
 		logger.Info("Generating host keys for remote shell server.")
 		var hostKeys hostKeys
-		shouldWrite, err := populateKeys(&hostKeys, logger)
+		addedKeys, err := populateKeys(&hostKeys, logger)
 
-		if shouldWrite && err == nil {
+		if (fileChanged || addedKeys) && err == nil {
 			writeKeys(defaultKeyfilePath, &hostKeys, logger)
 		}
 		return &hostKeys, err
@@ -381,9 +382,9 @@ func ensureHostKeys(logger *zap.Logger) (*hostKeys, error) {
 		}
 
 		// Populate missing keys (older files only have RSA)
-		shouldWrite, err := populateKeys(hostKeys, logger)
+		addedKeys, err := populateKeys(hostKeys, logger)
 
-		if shouldWrite && err == nil {
+		if (fileChanged || addedKeys) && err == nil {
 			writeKeys(defaultKeyfilePath, hostKeys, logger)
 		}
 		return hostKeys, err

--- a/remote_shell_service.go
+++ b/remote_shell_service.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/subtle"
@@ -17,10 +19,16 @@ import (
 	"github.com/gliderlabs/ssh"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
 
 type ConsoleTarget int32
+
+const (
+	RSAKeyType string = "RSA PRIVATE KEY"
+	ECKeyType         = "EC PRIVATE KEY"
+)
 
 const (
 	stdOutTarget ConsoleTarget = 0
@@ -194,55 +202,223 @@ func consoleInRoutine(stdIn io.Reader, console *Console, logger *zap.Logger) {
 	}
 }
 
-func ensureHostKey(logger *zap.Logger) (string, error) {
+const (
+	// Current filename, hides on Linux systems.
+	HostKeyFilename string = ".hostKey.pem"
+
+	// Old filename, not hidden.
+	OldHostKeyFilename = "hostKey.pem"
+)
+
+// Use the hidden form first, but fallback to the non-hidden one if it already exists.
+func pickHostKeyPath(homeDir string) string {
+	defaultKeyfilePath := filepath.Join(homeDir, HostKeyFilename)
+	_, err := os.Stat(defaultKeyfilePath)
+	if !os.IsNotExist(err) {
+		return defaultKeyfilePath
+	}
+
+	fallbackKeyfilePath := filepath.Join(homeDir, OldHostKeyFilename)
+	_, err = os.Stat(fallbackKeyfilePath)
+	if !os.IsNotExist(err) {
+		return fallbackKeyfilePath
+	}
+
+	return defaultKeyfilePath
+}
+
+// Exists to clean up the non-hidden key file if it still exists
+func cleanupOldHostKey() error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	keyfilePath := filepath.Join(homeDir, "hostKey.pem")
+	keyfilePath := filepath.Join(homeDir, OldHostKeyFilename)
 	_, err = os.Stat(keyfilePath)
 	if os.IsNotExist(err) {
-		logger.Info("Generating host key for remote shell server.")
-		hostKey, err := rsa.GenerateKey(rand.Reader, 4096)
-		if err != nil {
-			return keyfilePath, err
-		}
-
-		err = hostKey.Validate()
-		if err != nil {
-			return keyfilePath, err
-		}
-
-		hostDER := x509.MarshalPKCS1PrivateKey(hostKey)
-		hostBlock := pem.Block{
-			Type:    "RSA PRIVATE KEY",
-			Headers: nil,
-			Bytes:   hostDER,
-		}
-		hostPEM := pem.EncodeToMemory(&hostBlock)
-
-		err = os.WriteFile(keyfilePath, hostPEM, 0600)
-		return keyfilePath, err
+		return nil
 	}
 
-	return keyfilePath, err
+	err = os.Remove(keyfilePath)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(keyfilePath)
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+type hostKeys struct {
+	rsaKey *rsa.PrivateKey
+	ecKey  *ecdsa.PrivateKey
+}
+
+func populateKeys(keys *hostKeys, logger *zap.Logger) error {
+	if keys.ecKey == nil {
+		logger.Info("Generating ECDSA SSH Host Key")
+		ellipticKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			return err
+		}
+
+		keys.ecKey = ellipticKey
+	}
+
+	if keys.rsaKey == nil {
+		logger.Info("Generating RSA SSH Host Key")
+		rsaKey, err := rsa.GenerateKey(rand.Reader, 4096)
+		if err != nil {
+			return err
+		}
+
+		keys.rsaKey = rsaKey
+	}
+
+	return nil
+}
+
+func writeKeys(hostKeyPath string, keys *hostKeys, logger *zap.Logger) error {
+	keysFile, err := os.OpenFile(hostKeyPath, os.O_CREATE+os.O_WRONLY+os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer keysFile.Close()
+
+	logger.Info(fmt.Sprintf("Writing Host Keys to %s.", hostKeyPath))
+	if keys.ecKey != nil {
+		ecDER, err := x509.MarshalECPrivateKey(keys.ecKey)
+		if err != nil {
+			return err
+		}
+
+		ecBlock := pem.Block{
+			Type:  ECKeyType,
+			Bytes: ecDER,
+		}
+
+		pem.Encode(keysFile, &ecBlock)
+	}
+
+	if keys.rsaKey != nil {
+		rsaDER := x509.MarshalPKCS1PrivateKey(keys.rsaKey)
+		rsaBlock := pem.Block{
+			Type:  RSAKeyType,
+			Bytes: rsaDER,
+		}
+
+		pem.Encode(keysFile, &rsaBlock)
+	}
+
+	return nil
+}
+
+func readKeys(hostKeyPath string) (*hostKeys, error) {
+	bytes, err := os.ReadFile(hostKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys hostKeys
+	for len(bytes) > 0 {
+		pemBlock, next := pem.Decode(bytes)
+		if pemBlock == nil {
+			break
+		}
+
+		switch pemBlock.Type {
+		case RSAKeyType:
+			rsaKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+			if err != nil {
+				return &keys, err
+			}
+			keys.rsaKey = rsaKey
+		case ECKeyType:
+			ecKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+			if err != nil {
+				return &keys, err
+			}
+			keys.ecKey = ecKey
+		}
+
+		bytes = next
+	}
+
+	return &keys, nil
+}
+
+func ensureHostKeys(logger *zap.Logger) (*hostKeys, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	keyfilePath := pickHostKeyPath(homeDir)
+	defaultKeyfilePath := filepath.Join(homeDir, HostKeyFilename)
+	_, err = os.Stat(keyfilePath)
+	if os.IsNotExist(err) {
+		logger.Info("Generating host keys for remote shell server.")
+		var hostKeys hostKeys
+		err := populateKeys(&hostKeys, logger)
+
+		writeKeys(defaultKeyfilePath, &hostKeys, logger)
+		return &hostKeys, err
+	} else {
+		logger.Info(fmt.Sprintf("Reading host keys for remote shell from %s.", keyfilePath))
+		hostKeys, err := readKeys(keyfilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		// Populate missing keys (older files only have RSA)
+		err = populateKeys(hostKeys, logger)
+		writeKeys(defaultKeyfilePath, hostKeys, logger)
+		return hostKeys, err
+	}
+}
+
+func twinKeys(keys *hostKeys) ssh.Option {
+	return func(srv *ssh.Server) error {
+		rsaSigner, err := gossh.NewSignerFromKey(keys.rsaKey)
+		if err != nil {
+			return err
+		}
+		srv.AddHostKey(rsaSigner)
+
+		ecSigner, err := gossh.NewSignerFromKey(keys.ecKey)
+		if err != nil {
+			return err
+		}
+		srv.AddHostKey(ecSigner)
+
+		return nil
+	}
 }
 
 func runRemoteShellServer(console *Console, logger *zap.Logger) {
 	logger.Info("Starting remote shell server on 2222...")
 	ssh.Handle(func(s ssh.Session) { handleSession(s, console, logger) })
 
-	hostKeyPath, err := ensureHostKey(logger)
+	hostKeys, err := ensureHostKeys(logger)
 	if err != nil {
-		logger.Error("Unable to ensure host key exists", zap.Error(err))
+		logger.Error("Unable to ensure host keys exist", zap.Error(err))
 		return
+	}
+
+	err = cleanupOldHostKey()
+	if err != nil {
+		logger.Warn("Unable to remote old host key file", zap.Error(err))
 	}
 
 	log.Fatal(ssh.ListenAndServe(
 		":2222",
 		nil,
-		ssh.HostKeyFile(hostKeyPath),
+		twinKeys(hostKeys),
 		ssh.PasswordAuth(func(ctx ssh.Context, password string) bool { return passwordHandler(ctx, password, logger) }),
 	))
 }


### PR DESCRIPTION
### Purpose

Backup container would like to migrate to an integrated SSH client, unfortunately the easiest option only supports EC-based key exchange rather than both RSA and EC. As it's beneficial to support a broader set of clients anyways, this change adds an EC host key, allowing clients to use either type of key exchange. 

Additionally moves the hostKey.pem file to be .hostKey.pem to hide it by default. Backwards compatibility is supported by checking and reading either file, and if the old file was read and/or a missing key was added, writing both keys back out to the new file. This includes handling a pem file that is missing one or both keys. 

### Validation

Confirmed that with changes, the server side reports supporting ECDSA and RSA key exchange, using an SSH client library (SwiftNIO's SSH client). Also confirmed that using the library achieves the expected result: being able to connect and provide input to the process wrapped by mc-server-runner.

Confirmed that an openssh client can still connect same as without the changes.

Checked backwards compatibility scenarios around the hostKey.pem file:
- New file with just EC key
- New file with just RSA key
- New file with RSA and EC keys
- Old file with just RSA key
- Old file with RSA and EC keys