### PR TITLE
Fix Stop command quotes

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,10 @@ func main() {
 		logger.Fatal("Missing executable arguments")
 	}
 
+	if args.StopCommand != "" {
+		args.StopCommand = strings.ReplaceAll(args.StopCommand, "\"", "")
+	}
+
 	if args.Shell != "" {
 		cmd = exec.Command(args.Shell, flag.Args()...)
 	} else {


### PR DESCRIPTION
Hello,

After the recent change which was the removal of the args.StopCommand replace it seems the command is now sent between quotes.

Here is the bug it produces:

![image](https://github.com/user-attachments/assets/f174d329-7990-4a64-b828-ef107f6acdf9)

The command that the server handle is not correctly parsed.