### PR TITLE
Upgrade to Go 1.24.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,7 @@
 {
 	"name": "Go",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
-			"VARIANT": "1.21"
-		}
+		"dockerfile": "Dockerfile"
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.24.5"
+      go-version: "1.24.6"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.24.5"
+      go-version: "1.24.6"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/itzg/mc-server-runner
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Addresses

```
=== Symbol Results ===

Vulnerability #1: GO-2025-3956
    Unexpected paths returned from LookPath in os/exec
  More info: https://pkg.go.dev/vuln/GO-2025-3956
  Standard library
    Found in: os/exec@go1.24.5
    Fixed in: os/exec@go1.24.6
    Example traces found:
Error:       #1: main.go:66:21: mc.main calls exec.Command, which calls exec.LookPath
```